### PR TITLE
NP deprecation: np.int -> int; np.float -> float

### DIFF
--- a/oxasl/basil/fabber_method.py
+++ b/oxasl/basil/fabber_method.py
@@ -87,7 +87,7 @@ def _surf_pvcorr(wsp):
     wsp.rois.mask_pvcorr = wsp.rois.mask
     min_pv = 0.01
     new_roi = (wsp.basil_options["pwm"].data > min_pv) | (wsp.basil_options["pgm"].data > min_pv)
-    wsp.rois.mask = Image(new_roi.astype(np.int8), header=wsp.rois.mask_pvcorr.header)
+    wsp.rois.mask = Image(new_roi.astype(int), header=wsp.rois.mask_pvcorr.header)
 
     multistep_fit.run(wsp.sub("basil_surf_pvcorr"), prefit=False)
     wsp.quantify_wsps.append("basil_surf_pvcorr")

--- a/oxasl/basil/multistep_fit.py
+++ b/oxasl/basil/multistep_fit.py
@@ -141,7 +141,7 @@ def _define_mask(wsp):
             # Use 3x3x3 kernel for compatibility with fslmaths default
             wsp.log.write(" - Dilating mask for Basil analysis\n")
             struct = scipy.ndimage.generate_binary_structure(3, 3)
-            wsp.basil_mask = Image(scipy.ndimage.binary_dilation(wsp.basil_mask.data, structure=struct).astype(np.int), header=wsp.basil_mask.header)
+            wsp.basil_mask = Image(scipy.ndimage.binary_dilation(wsp.basil_mask.data, structure=struct).astype(int), header=wsp.basil_mask.header)
     elif mask_policy == "none":
             wsp.log.write(" - Not using mask for Basil - will fit every voxel\n")
             wsp.basil_mask = Image(np.ones(wsp.asldata.data.shape[:3]), header=wsp.asldata.header)

--- a/oxasl/distcorr.py
+++ b/oxasl/distcorr.py
@@ -93,7 +93,7 @@ def get_cblip_correction(wsp):
         "y"  : 1, "-y" : 1,
         "z"  : 2, "-z" : 2,
     }
-    my_topup_params = np.array(topup_params[wsp.pedir], dtype=np.float)
+    my_topup_params = np.array(topup_params[wsp.pedir], dtype=float)
     dimsize = wsp.asldata.shape[dim_idx[wsp.pedir]]
     my_topup_params[:, 3] = wsp.echospacing * (dimsize - 1)
     wsp.topup.params = my_topup_params

--- a/oxasl/m0.py
+++ b/oxasl/m0.py
@@ -175,7 +175,7 @@ def get_m0_voxelwise(wsp):
     # Calculate M0 value
     wsp.calib_img = wsp.corrected.calib
     calib_data = wsp.calib_img.data
-    m0 = calib_data.astype(np.float) * gain
+    m0 = calib_data.astype(float) * gain
 
     shorttr = 1
     if wsp.tr is not None and wsp.tr < 5:
@@ -335,7 +335,7 @@ def get_m0_wholebrain(wsp):
         wsp.log.write(" - Using sensitivity image: %s\n" % wsp.sens.name)
         calib_data /= wsp.sens.data
 
-    m0 = np.zeros(calib_data.shape, dtype=np.float)
+    m0 = np.zeros(calib_data.shape, dtype=float)
     for tiss_type in ("wm", "gm", "csf"):
         pve_struc = getattr(wsp.structural, "%s_pv" % tiss_type)
         wsp.log.write(" - Transforming %s tissue PVE into ASL space\n" % tiss_type)
@@ -469,7 +469,7 @@ def get_m0_refregion(wsp, mode="longtr"):
 
     if wsp.refmask is not None:
         wsp.log.write(" - Using supplied reference tissue mask: %s" % wsp.refmask.name)
-        wsp.refmask = Image(wsp.refmask.data.astype(np.int), header=wsp.refmask.header)
+        wsp.refmask = Image(wsp.refmask.data.astype(int), header=wsp.refmask.header)
         if wsp.calib_aslreg:
             wsp.log.write(" (Aligned to ASL image already)\n")
             wsp.refmask_trans = wsp.refmask
@@ -646,8 +646,8 @@ def get_tissrefmask(wsp):
         atlases = AtlasRegistry()
         atlases.rescanAtlases()
         atlas = atlases.loadAtlas("harvardoxford-subcortical", loadSummary=False, resolution=2)
-        ventricles = ((atlas.data[..., 2] + atlas.data[..., 13]) > 0.1).astype(np.int)
-        wsp.ventricles = Image(scipy.ndimage.binary_erosion(ventricles, structure=np.ones([3, 3, 3]), border_value=1).astype(np.int), header=atlas.header)
+        ventricles = ((atlas.data[..., 2] + atlas.data[..., 13]) > 0.1).astype(int)
+        wsp.ventricles = Image(scipy.ndimage.binary_erosion(ventricles, structure=np.ones([3, 3, 3]), border_value=1).astype(int), header=atlas.header)
         std_img = Image(os.path.join(os.environ["FSLDIR"], "data", "standard", 'MNI152_T1_2mm_brain'))
         page.image("ventricles_std", LightboxImage(wsp.ventricles, bgimage=std_img))
 
@@ -678,7 +678,7 @@ def get_tissrefmask(wsp):
 
     # Threshold reference mask conservatively to select only reference tissue
     wsp.log.write(" - Thresholding reference mask\n")
-    wsp.refmask = Image((wsp.refpve_calib.data > 0.9).astype(np.int), header=wsp.refpve_calib.header)
+    wsp.refmask = Image((wsp.refpve_calib.data > 0.9).astype(int), header=wsp.refpve_calib.header)
 
     page.text("Reference Mask (thresholded at 0.9")
     page.image("refmask", LightboxImage(wsp.refmask, bgimage=wsp.calib_img))

--- a/oxasl/mask.py
+++ b/oxasl/mask.py
@@ -67,12 +67,12 @@ def run(wsp):
         page.image("struc_brain", LightboxImage(wsp.structural.brain, bgimage=wsp.structural.struc))
         wsp.rois.mask_struc = wsp.structural.brain_mask
         wsp.rois.mask_asl = reg.change_space(wsp, wsp.structural.brain_mask, "asl")
-        wsp.rois.mask = Image(sp.ndimage.morphology.binary_fill_holes((wsp.rois.mask_asl.data > 0.25)).astype(np.int), header=wsp.rois.mask_asl.header)
+        wsp.rois.mask = Image(sp.ndimage.morphology.binary_fill_holes((wsp.rois.mask_asl.data > 0.25)).astype(int), header=wsp.rois.mask_asl.header)
         mask_source = "generated from brain extracting structural image and registering to ASL space"
     else:
         # Alternatively, use registration image (which will be BETed calibration or mean ASL image)
         wsp.rois.mask_src = "aslref"
-        wsp.rois.mask = Image((wsp.reg.aslref.data != 0).astype(np.int), header=wsp.reg.aslref.header)
+        wsp.rois.mask = Image((wsp.reg.aslref.data != 0).astype(int), header=wsp.reg.aslref.header)
         mask_source = "generated from brain extracted registration ASL image"
 
     wsp.log.write(" - Mask %s\n" % mask_source)

--- a/oxasl/options.py
+++ b/oxasl/options.py
@@ -149,7 +149,7 @@ def load_matrix(fname):
         for line in f.readlines():
             if line.strip():
                 matrix.append([float(v) for v in line.strip().split()])
-    return np.array(matrix, dtype=np.float)
+    return np.array(matrix, dtype=float)
 
 def _check_image(option, opt, value):
     try:

--- a/oxasl/reg.py
+++ b/oxasl/reg.py
@@ -430,7 +430,7 @@ def transform(wsp, img, trans, ref, use_flirt=False, interp="trilinear", padding
 
     if mask:
         # Binarise mask images
-        ret = Image((ret.data > mask_thresh).astype(np.int), header=ret.header)
+        ret = Image((ret.data > mask_thresh).astype(int), header=ret.header)
     return ret
 
 def reg_flirt(wsp, img, ref, initial_transform=None):
@@ -558,7 +558,7 @@ def get_transform_params(mat):
             mat[2, 1] - mat[1, 2],
             mat[0, 2] - mat[2, 0],
             mat[1, 0] - mat[0, 1],
-        ], dtype=np.float)
+        ], dtype=float)
 
         # Rotation angle - note that we need to check the sign
         trace = np.trace(mat[:3, :3])

--- a/oxasl/region_analysis.py
+++ b/oxasl/region_analysis.py
@@ -204,7 +204,7 @@ def get_stats_fuzzy(wsp, stats, img, var_img, roi_set, suffix="",
         raise ValueError("Mask must have same dimensions as ROI")
 
     if mask is None:
-        mask = np.ones(roi_shape, dtype=np.int)
+        mask = np.ones(roi_shape, dtype=int)
     if ignore_nan:
         mask = np.logical_and(mask, ~np.isnan(img))
     if ignore_inf:
@@ -260,7 +260,7 @@ def apply_psf(array, psf):
         return array
 
     # Make sure array is 4D
-    array = array.astype(np.float)
+    array = array.astype(float)
     was_3d = False
     if array.ndim == 3:
         was_3d = True
@@ -319,7 +319,7 @@ def add_roi(wsp, rois, name, roi, threshold):
     rois.append({
         "name" : name,
         "roi_asl" : roi_asl,
-        "mask_asl" : (roi_asl.data > threshold).astype(np.int),
+        "mask_asl" : (roi_asl.data > threshold).astype(int),
         "roi_%s" % roi_space : roi,
     })
     wsp.log.write("DONE\n")
@@ -401,7 +401,7 @@ def add_rois_from_3d_label_atlas(wsp, rois, atlas_img, region_names):
 
     for name, label in zip(region_names, labels):
         roi_data = atlas_img.data.copy()
-        roi_bin = (roi_data == label).astype(np.int)
+        roi_bin = (roi_data == label).astype(int)
         roi = Image(roi_bin, header=atlas_img.header)
         add_roi(wsp, rois, name, roi, threshold=0.5)
 

--- a/oxasl/reporting.py
+++ b/oxasl/reporting.py
@@ -165,7 +165,7 @@ class LightboxImage(object):
                         data = np.clip(data, vmin, vmax)
 
                 if self._outline:
-                    data = (data > 0.5).astype(np.int)
+                    data = (data > 0.5).astype(int)
                     data = data - scipy.ndimage.morphology.binary_erosion(data, structure=np.ones((3, 3)))
 
                 if self._mask:

--- a/oxasl/senscorr.py
+++ b/oxasl/senscorr.py
@@ -71,14 +71,14 @@ def run(wsp):
         wsp.log.write(" - Sensitivity image calculated from calibration actual and reference images\n")
         cref_data = np.copy(wsp.cref.data)
         cref_data[cref_data == 0] = 1
-        sensitivity = Image(wsp.cact.data.astype(np.float) / cref_data, header=wsp.calib.header)
+        sensitivity = Image(wsp.cact.data.astype(float) / cref_data, header=wsp.calib.header)
     elif wsp.calib is not None and wsp.cref is not None:
         if wsp.ifnone("mode", "longtr") != "longtr":
             raise ValueError("Calibration reference image specified but calibration image was not in longtr mode - need to provided additional calibration image using the ASL coil")
         wsp.log.write(" - Sensitivity image calculated from calibration and reference images\n")
         cref_data = np.copy(wsp.cref.data)
         cref_data[cref_data == 0] = 1
-        sensitivity = Image(wsp.calib.data.astype(np.float) / cref_data, header=wsp.calib.header)
+        sensitivity = Image(wsp.calib.data.astype(float) / cref_data, header=wsp.calib.header)
     elif wsp.senscorr_auto and wsp.structural.bias is not None:
         wsp.log.write(" - Sensitivity image calculated from bias field\n")
         bias = reg.change_space(wsp, wsp.structural.bias, "asl")

--- a/oxasl/struc.py
+++ b/oxasl/struc.py
@@ -78,7 +78,7 @@ def run(wsp):
     if wsp.structural.brain is not None and wsp.structural.brain_mask is None:
         # FIXME - for now get the mask by binarising the brain image for compatibility with oxford_asl
         # although this gives slightly different results compared to using the mask returned by BET
-        wsp.structural.brain_mask = Image((wsp.structural.brain.data != 0).astype(np.int), header=wsp.structural.struc.header)
+        wsp.structural.brain_mask = Image((wsp.structural.brain.data != 0).astype(int), header=wsp.structural.struc.header)
 
     if wsp.structural.struc is not None:
         segment(wsp)
@@ -127,11 +127,11 @@ def segment(wsp):
             raise ValueError("No structural data provided - cannot segment")
 
         if wsp.structural.csf_seg is None:
-            wsp.structural.csf_seg = Image((wsp.structural.csf_pv.data > 0.5).astype(np.int), header=wsp.structural.struc.header)
+            wsp.structural.csf_seg = Image((wsp.structural.csf_pv.data > 0.5).astype(int), header=wsp.structural.struc.header)
         if wsp.structural.gm_seg is None:
-            wsp.structural.gm_seg = Image((wsp.structural.gm_pv.data > 0.5).astype(np.int), header=wsp.structural.struc.header)
+            wsp.structural.gm_seg = Image((wsp.structural.gm_pv.data > 0.5).astype(int), header=wsp.structural.struc.header)
         if wsp.structural.wm_seg is None:
-            wsp.structural.wm_seg = Image((wsp.structural.wm_pv.data > 0.5).astype(np.int), header=wsp.structural.struc.header)
+            wsp.structural.wm_seg = Image((wsp.structural.wm_pv.data > 0.5).astype(int), header=wsp.structural.struc.header)
 
         page.heading("Segmentation image", level=1)
         page.text("CSF partial volume")


### PR DESCRIPTION
Resolves #19 

Numpy > 1.22 has deprecated np.int and np.float dtypes which are just aliases for built-in int and float. On Numpy version 1.24 the deprecation raises an error. 